### PR TITLE
Constants.lua: add Champion's Challenge

### DIFF
--- a/DebuffVitals/Constants.lua
+++ b/DebuffVitals/Constants.lua
@@ -53,6 +53,7 @@ DEFAULT_FREEP_EFFECTS =  {
     {"Champion",    "Horn of Champions",                        0, 0},    
     {"Champion",    "Horn of Gondor Physical Mitigation",       0, 0},    
     {"Champion",    "Rend",                                     0, 0, "Rend Tier"},
+    {"Champion",    "Champion's Challenge",                     0, 0, "Furious Impotence"},
     {"Guardian",    "Take to Heart",                            0, 1},
     {"Guardian",    "Marked by Light",                          0, 1},
     {"Guardian",    "Slashing Wound",                           0, 0},


### PR DESCRIPTION
The Champion's Challenge skill now has a debuff effect called "Furious Impotence" that gives -30% outgoing damage.